### PR TITLE
Fix TodoList date default

### DIFF
--- a/models/TodoListModel.py
+++ b/models/TodoListModel.py
@@ -1,10 +1,12 @@
-from datetime import datetime
+from datetime import date
 from configs.dbconfig import db
+
 
 class TodoList(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     content = db.Column(db.String(200), nullable=False)
-    date_created = db.Column(db.Date, default=datetime.today().date)
-    
+    # Use a callable so the date is evaluated when a task is created, not at import time.
+    date_created = db.Column(db.Date, default=date.today)
+
     def __repr__(self):
         return 'Task %r' % self.id


### PR DESCRIPTION
## Summary
- ensure `TodoList` uses `date.today` callable so each new task records its own creation date

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896d27d54a08321be3b15a54213cf70